### PR TITLE
Fixed derivative handling of pid

### DIFF
--- a/src/PID.cpp
+++ b/src/PID.cpp
@@ -269,18 +269,6 @@ PID::update ( double _measuredValue, double _referenceValue, double time  )
     prevValue = _measuredValue; //update old process output
 
     
-/*    cout 
-	<< " t " << time 
-	<< ", y " << _measuredValue
-	<< ", ysp " << _referenceValue
-	<< ", err " << _referenceValue - _measuredValue
-	<< ", P " << P 
-	<< ", I " << I 
-	<< ", D " << D 
-	<< ", rC " << rawCommand 
-	<< ", sC " << saturatedCommand << endl;
-*/	
-
     return saturatedCommand;
 }
 

--- a/src/PID.cpp
+++ b/src/PID.cpp
@@ -60,7 +60,7 @@ PID::PID():
 initialized(false),prevValue(0),prevError(0),Bi(0),Ad(0),Bd(0),Ao(0),P(0),
 I(0),D(0),rawCommand(0),saturatedCommand(0),bIntegral(false),
 bDerivative(false),bDerivativeFiltering(false),Kold(0),Bold(0),
-firstRun(true),bSaturated(false),derivativeMode(Error)
+firstRun(true),bSaturated(false),derivativeMode(Output)
 { 
 };
 

--- a/src/PID.hpp
+++ b/src/PID.hpp
@@ -186,6 +186,18 @@ namespace motor_controller
         double saturatedOutput;
     };
 
+    /** Representation of the derivative modes.
+    *
+    * Error: the derivative is applied to the error
+    * Output: the derivative is applied to the output only (avoid kicks due
+    * to setpoint changes)
+    */
+    enum DerivativeMode
+    {
+    	Error,
+		Output
+    };
+
 	/**
 	 * \brief PID Implementation in C++
 	 *
@@ -295,7 +307,7 @@ namespace motor_controller
 	    //! Enables the integral part of the controller with time constant \c _Ti
 	    void enableIntegral(double _Ti); 
 
-	    //! return if integral part is enabled 
+	    //! Returns whether integral part is enabled
 	    bool isIntegralEnabled() const { return bIntegral; }
 
 
@@ -308,9 +320,8 @@ namespace motor_controller
 	    //! Enables the derivative part of the controller with time constant \c _Td 
 	    void enableDerivative(double _Td); 
 
-	    //! return if derivative part is enabled 
+	    //! Returns whether derivative part is enabled
 	    bool isDerivativeEnabled() const { return bDerivative; }
-
 
 	    //! Diables the derivative filtering 
 	    void disableDerivativeFiltering(); 
@@ -319,10 +330,20 @@ namespace motor_controller
 	    void enableDerivativeFiltering(); 
 
 	    //! Enables the derivative filtering with time constant \c _N
-	    void enableDerivativeFiltering(double _N)  ; 
+	    void enableDerivativeFiltering(double _N);
 
-	    //! return if derivative filtering part is enabled 
+	    //! Returns whether derivative filtering part is enabled
 	    bool isDerivativeFilteringEnabled() const { return bDerivativeFiltering; }
+
+	    //! Sets the derivative mode
+	    /**
+	    * \param mode - Defines if the derivative will be applied to the
+	    * 				 error or only to the output
+	    */
+	    void setDerivativeMode(DerivativeMode mode);
+
+	    //! Returns the current derivative mode
+	    DerivativeMode getDerivativeMode() const;
 
         //! Returns true if the controller got saturated in the last run
         bool isSaturated();
@@ -337,6 +358,9 @@ namespace motor_controller
 
 		//! true if coefficients initialized atleast once
 	    bool initialized;
+
+	    //! measured value from previous step
+	    double prevValue;
 
 		//! previous error value 
 	    double prevError;
@@ -355,6 +379,8 @@ namespace motor_controller
 	    bool bDerivative;
 		//! false turns off Derivative Filtering
 	    bool bDerivativeFiltering;
+	    //! Defines the derivative mode (error or output)
+	    DerivativeMode derivativeMode;
 
 		//! Bumpless parameter change- old value of K if parameter changed
 	    double Kold;

--- a/src/PID.hpp
+++ b/src/PID.hpp
@@ -338,8 +338,8 @@ namespace motor_controller
 		//! true if coefficients initialized atleast once
 	    bool initialized;
 
-		//! measured value from previous step
-	    double prevValue;
+		//! previous error value 
+	    double prevError;
 
 		//! reference value from previous step
 	    double prevReferenceValue;

--- a/src/PID.hpp
+++ b/src/PID.hpp
@@ -295,6 +295,9 @@ namespace motor_controller
 	    //! Enables the integral part of the controller with time constant \c _Ti
 	    void enableIntegral(double _Ti); 
 
+	    //! return if integral part is enabled 
+	    bool isIntegralEnabled() const { return bIntegral; }
+
 
 	    //! Diables the derivative part of the controller 
 	    void disableDerivative(); 
@@ -305,6 +308,9 @@ namespace motor_controller
 	    //! Enables the derivative part of the controller with time constant \c _Td 
 	    void enableDerivative(double _Td); 
 
+	    //! return if derivative part is enabled 
+	    bool isDerivativeEnabled() const { return bDerivative; }
+
 
 	    //! Diables the derivative filtering 
 	    void disableDerivativeFiltering(); 
@@ -314,6 +320,9 @@ namespace motor_controller
 
 	    //! Enables the derivative filtering with time constant \c _N
 	    void enableDerivativeFiltering(double _N)  ; 
+
+	    //! return if derivative filtering part is enabled 
+	    bool isDerivativeFilteringEnabled() const { return bDerivativeFiltering; }
 
         //! Returns true if the controller got saturated in the last run
         bool isSaturated();


### PR DESCRIPTION
In cases where the input value stays constant, and the reference value is changing, the previous implementation would lead to the derivative value not being used.

To calculate the derivative, only the input value was used, instead of the full error value (e.g. the reference - input).

Changed the implementation to store the error instead of the previous input value, and use that to calculate the derivative.

I'm citing @jakobs here ;)
