### PR TITLE
Now the derivative can be applied either to the error or only to the output

### DIFF
--- a/src/PID.hpp
+++ b/src/PID.hpp
@@ -186,6 +186,18 @@ namespace motor_controller
         double saturatedOutput;
     };
 
+    /** Representation of the derivative modes.
+    *
+    * Error: the derivative is applied to the error
+    * Output: the derivative is applied to the output only (avoid kicks due
+    * to setpoint changes)
+    */
+    enum DerivativeMode
+    {
+    	Error,
+		Output
+    };
+
 	/**
 	 * \brief PID Implementation in C++
 	 *
@@ -295,7 +307,7 @@ namespace motor_controller
 	    //! Enables the integral part of the controller with time constant \c _Ti
 	    void enableIntegral(double _Ti); 
 
-	    //! return if integral part is enabled 
+	    //! Returns whether integral part is enabled
 	    bool isIntegralEnabled() const { return bIntegral; }
 
 
@@ -308,9 +320,8 @@ namespace motor_controller
 	    //! Enables the derivative part of the controller with time constant \c _Td 
 	    void enableDerivative(double _Td); 
 
-	    //! return if derivative part is enabled 
+	    //! Returns whether derivative part is enabled
 	    bool isDerivativeEnabled() const { return bDerivative; }
-
 
 	    //! Diables the derivative filtering 
 	    void disableDerivativeFiltering(); 
@@ -319,10 +330,20 @@ namespace motor_controller
 	    void enableDerivativeFiltering(); 
 
 	    //! Enables the derivative filtering with time constant \c _N
-	    void enableDerivativeFiltering(double _N)  ; 
+	    void enableDerivativeFiltering(double _N);
 
-	    //! return if derivative filtering part is enabled 
+	    //! Returns whether derivative filtering part is enabled
 	    bool isDerivativeFilteringEnabled() const { return bDerivativeFiltering; }
+
+	    //! Sets the derivative mode
+	    /**
+	    * \param mode - Defines if the derivative will be applied to the
+	    * 				 error or only to the output
+	    */
+	    void setDerivativeMode(DerivativeMode mode);
+
+	    //! Returns the current derivative mode
+	    DerivativeMode getDerivativeMode() const;
 
         //! Returns true if the controller got saturated in the last run
         bool isSaturated();
@@ -337,6 +358,9 @@ namespace motor_controller
 
 		//! true if coefficients initialized atleast once
 	    bool initialized;
+
+	    //! measured value from previous step
+	    double prevValue;
 
 		//! previous error value 
 	    double prevError;
@@ -355,6 +379,8 @@ namespace motor_controller
 	    bool bDerivative;
 		//! false turns off Derivative Filtering
 	    bool bDerivativeFiltering;
+	    //! Defines the derivative mode (error or output)
+	    DerivativeMode derivativeMode;
 
 		//! Bumpless parameter change- old value of K if parameter changed
 	    double Kold;


### PR DESCRIPTION
I've made the changes we have discussed, and basically, now the user can choose between aplying the derivative action to the error or only to the output.

As default, I followed Jakob suggestion and the derivative action is applied to the error.
